### PR TITLE
v2.0.0: .NET 10 retarget + AOT/trim compatibility

### DIFF
--- a/EnabledProvider.cs
+++ b/EnabledProvider.cs
@@ -291,7 +291,7 @@ namespace etwlib
 
             var matchAllFlags = Filters.ConvertAll(f => Convert.ToByte(f.Item2)).ToArray();
             var eventFilterDescriptor = Marshal.AllocHGlobal(
-                Marshal.SizeOf(typeof(EVENT_FILTER_DESCRIPTOR)));
+                Marshal.SizeOf<EVENT_FILTER_DESCRIPTOR>());
             if (eventFilterDescriptor == nint.Zero)
             {
                 throw new Exception("Out of memory");
@@ -411,7 +411,7 @@ namespace etwlib
 
             var descriptor = new EVENT_FILTER_DESCRIPTOR();
             descriptor.Type = EventFilterTypeStackWalkLevelKw;
-            descriptor.Size = (uint)Marshal.SizeOf(typeof(EVENT_FILTER_LEVEL_KW));
+            descriptor.Size = (uint)Marshal.SizeOf<EVENT_FILTER_LEVEL_KW>();
             descriptor.Ptr = Marshal.AllocHGlobal((int)descriptor.Size);
             if (descriptor.Ptr == nint.Zero)
             {
@@ -457,7 +457,7 @@ namespace etwlib
                 //
                 // EnableTraceEx2 expects an array of EVENT_FILTER_DESCRIPTOR
                 //
-                var size = Marshal.SizeOf(typeof(EVENT_FILTER_DESCRIPTOR));
+                var size = Marshal.SizeOf<EVENT_FILTER_DESCRIPTOR>();
                 m_FiltersBuffer = Marshal.AllocHGlobal(numFilters * size);
                 if (m_FiltersBuffer == nint.Zero)
                 {
@@ -471,8 +471,8 @@ namespace etwlib
                 }
                 if (m_AggregatedPayloadFilters != nint.Zero)
                 {
-                    var payloadFilter = (EVENT_FILTER_DESCRIPTOR)Marshal.PtrToStructure(
-                        m_AggregatedPayloadFilters, typeof(EVENT_FILTER_DESCRIPTOR))!;
+                    var payloadFilter = Marshal.PtrToStructure<EVENT_FILTER_DESCRIPTOR>(
+                        m_AggregatedPayloadFilters);
                     Debug.Assert(payloadFilter.Type == EventFilterTypePayload);
                     Debug.Assert(payloadFilter.Ptr != nint.Zero);
                     Marshal.StructureToPtr(payloadFilter, pointer, false);
@@ -492,7 +492,7 @@ namespace etwlib
                 }
             }
 
-            m_ParametersBuffer = Marshal.AllocHGlobal(Marshal.SizeOf(parameters));
+            m_ParametersBuffer = Marshal.AllocHGlobal(Marshal.SizeOf<ENABLE_TRACE_PARAMETERS>());
             Marshal.StructureToPtr(parameters, m_ParametersBuffer, false);
             return m_ParametersBuffer;
         }
@@ -503,8 +503,8 @@ namespace etwlib
         {
             var descriptor = new EVENT_FILTER_DESCRIPTOR();
             descriptor.Type = FilterType;
-            var size = Marshal.SizeOf(typeof(EVENT_FILTER_EVENT_ID)) +
-                ((EventIds.Count - 1) * Marshal.SizeOf(typeof(ushort)));
+            var size = Marshal.SizeOf<EVENT_FILTER_EVENT_ID>() +
+                ((EventIds.Count - 1) * Marshal.SizeOf<ushort>());
             descriptor.Size = (uint)size;
             descriptor.Ptr = Marshal.AllocHGlobal(size);
             if (descriptor.Ptr == nint.Zero)
@@ -518,7 +518,7 @@ namespace etwlib
             Marshal.StructureToPtr(filter, descriptor.Ptr, false);
             var dest = nint.Add(descriptor.Ptr, (int)Marshal.OffsetOf<EVENT_FILTER_EVENT_ID>("Events"));
             var ids = EventIds.ConvertAll(id => (ushort)id).ToArray();
-            var byteSize = ids.Length * Marshal.SizeOf(typeof(ushort));
+            var byteSize = ids.Length * Marshal.SizeOf<ushort>();
             var bytes = new byte[byteSize];
             Buffer.BlockCopy(ids, 0, bytes, 0, byteSize);
             Marshal.Copy(bytes, 0, dest, byteSize);

--- a/EventParser.cs
+++ b/EventParser.cs
@@ -55,7 +55,7 @@ namespace etwlib
             m_SkipUserData = true;
             m_Buffers = Buffers;
             var record = new EVENT_RECORD();
-            record.EventHeader.Size = (ushort)Marshal.SizeOf(typeof(EVENT_RECORD));
+            record.EventHeader.Size = (ushort)Marshal.SizeOf<EVENT_RECORD>();
             record.EventHeader.Descriptor = EventDescriptor;
             record.EventHeader.ProviderId = ProviderGuid;
             m_Buffers.SetEvent(record);
@@ -390,8 +390,7 @@ namespace etwlib
             nint buffer = m_Buffers.m_Event.ExtendedData;
             for (int i = 0; i < m_Buffers.m_Event.ExtendedDataCount; i++)
             {
-                var item = (EVENT_HEADER_EXTENDED_DATA_ITEM)Marshal.PtrToStructure(
-                    buffer, typeof(EVENT_HEADER_EXTENDED_DATA_ITEM))!;
+                var item = Marshal.PtrToStructure<EVENT_HEADER_EXTENDED_DATA_ITEM>(buffer);
                 var size = (int)item.DataSize;
                 if (size == 0)
                 {
@@ -454,7 +453,7 @@ namespace etwlib
                         $", pointer 0x{item.DataPtr:X}: {ex.Message}");
                     return false;
                 }
-                size = Marshal.SizeOf(typeof(EVENT_HEADER_EXTENDED_DATA_ITEM));
+                size = Marshal.SizeOf<EVENT_HEADER_EXTENDED_DATA_ITEM>();
                 buffer = nint.Add(buffer, size);
             }
             return true;

--- a/EventParserBuffers.cs
+++ b/EventParserBuffers.cs
@@ -109,8 +109,7 @@ namespace etwlib
 
         public void SetTraceInfo()
         {
-            m_TraceEventInfo = (TRACE_EVENT_INFO)Marshal.PtrToStructure(
-                m_TraceEventInfoBuffer, typeof(TRACE_EVENT_INFO))!;
+            m_TraceEventInfo = Marshal.PtrToStructure<TRACE_EVENT_INFO>(m_TraceEventInfoBuffer);
         }
 
         public void SetTraceInfo(nint Buffer)
@@ -125,8 +124,7 @@ namespace etwlib
 
         public void SetMapInfoBuffer()
         {
-            m_MapInfo = (EVENT_MAP_INFO)Marshal.PtrToStructure(
-                m_TdhMapBuffer, typeof(EVENT_MAP_INFO))!;
+            m_MapInfo = Marshal.PtrToStructure<EVENT_MAP_INFO>(m_TdhMapBuffer);
         }
     }
 }

--- a/MarshalHelper.cs
+++ b/MarshalHelper.cs
@@ -17,20 +17,27 @@ specific language governing permissions and limitations
 under the License.
 */
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace etwlib
 {
     public static class MarshalHelper
     {
+        private const DynamicallyAccessedMemberTypes StructMembers =
+            DynamicallyAccessedMemberTypes.PublicConstructors |
+            DynamicallyAccessedMemberTypes.NonPublicConstructors |
+            DynamicallyAccessedMemberTypes.PublicFields |
+            DynamicallyAccessedMemberTypes.NonPublicFields;
+
         public
         static
         object?
-        MarshalArbitraryType<T>(nint Pointer)
+        MarshalArbitraryType<[DynamicallyAccessedMembers(StructMembers)] T>(nint Pointer)
         {
             try
             {
-                return Convert.ChangeType(Marshal.PtrToStructure(Pointer, typeof(T)), typeof(T));
+                return Convert.ChangeType(Marshal.PtrToStructure<T>(Pointer), typeof(T));
             }
             catch (Exception ex)
             {
@@ -43,7 +50,7 @@ namespace etwlib
         public
         static
         List<T>
-        MarshalArray<T>(nint ArrayAddress, uint ElementCount)
+        MarshalArray<[DynamicallyAccessedMembers(StructMembers)] T>(nint ArrayAddress, uint ElementCount)
         {
             nint entry = ArrayAddress;
             var result = new List<T>();
@@ -59,7 +66,7 @@ namespace etwlib
                 //
                 unsafe
                 {
-                    entry = (nint)((byte*)entry.ToPointer() + Marshal.SizeOf(typeof(T)));
+                    entry = (nint)((byte*)entry.ToPointer() + Marshal.SizeOf<T>());
                 }
             }
             return result;

--- a/NativeDefinitions.cs
+++ b/NativeDefinitions.cs
@@ -33,7 +33,7 @@ namespace etwlib
 
     }
 
-    public static class NativeTraceControl
+    public static partial class NativeTraceControl
     {
         #region Enums
         public enum EventTraceLevel : byte
@@ -397,53 +397,53 @@ namespace etwlib
         #endregion
 
         #region APIs
-        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern uint StartTrace(
-            [In, Out] ref long SessionHandle,
-            [In] string SessionName,
-            [In, Out] nint Properties // EVENT_TRACE_PROPERTIES
+        [LibraryImport("advapi32.dll", EntryPoint = "StartTraceW", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+        public static partial uint StartTrace(
+            ref long SessionHandle,
+            string SessionName,
+            nint Properties // EVENT_TRACE_PROPERTIES
         );
 
-        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern uint ControlTrace(
-            [In] long SessionHandle,
-            [In] string SessionName,
-            [In, Out] nint Properties, // EVENT_TRACE_PROPERTIES
-            [In] ControlCode ControlCode
+        [LibraryImport("advapi32.dll", EntryPoint = "ControlTraceW", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+        public static partial uint ControlTrace(
+            long SessionHandle,
+            string SessionName,
+            nint Properties, // EVENT_TRACE_PROPERTIES
+            ControlCode ControlCode
         );
 
-        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern long OpenTrace(
-            [In, Out] nint LogFile // EVENT_TRACE_LOGFILE*
+        [LibraryImport("advapi32.dll", EntryPoint = "OpenTraceW", SetLastError = true)]
+        public static partial long OpenTrace(
+            nint LogFile // EVENT_TRACE_LOGFILE*
         );
 
-        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint CloseTrace(
-            [In] long SessionHandle
-            );
+        [LibraryImport("advapi32.dll", SetLastError = true)]
+        internal static partial uint CloseTrace(
+            long SessionHandle
+        );
 
-        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern uint ProcessTrace(
+        [LibraryImport("advapi32.dll", SetLastError = true)]
+        public static partial uint ProcessTrace(
             [In] long[] handleArray,
-            [In] uint handleCount,
-            [In] nint StartTime,
-            [In] nint EndTime);
+            uint handleCount,
+            nint StartTime,
+            nint EndTime);
 
-        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern uint EnableTraceEx2(
-          [In] long SessionHandle,
-          [In] Guid ProviderId,
-          [In] EventControlCode ControlCode,
-          [In] byte Level,
-          [In] ulong MatchAnyKeyword,
-          [In] ulong MatchAllKeyword,
-          [In] uint Timeout,
-          [In, Optional] nint EnableParameters // ENABLE_TRACE_PARAMETERS
+        [LibraryImport("advapi32.dll", SetLastError = true)]
+        public static partial uint EnableTraceEx2(
+            long SessionHandle,
+            Guid ProviderId,
+            EventControlCode ControlCode,
+            byte Level,
+            ulong MatchAnyKeyword,
+            ulong MatchAllKeyword,
+            uint Timeout,
+            nint EnableParameters // ENABLE_TRACE_PARAMETERS
         );
         #endregion
     }
 
-    public static class NativeTraceConsumer
+    public static partial class NativeTraceConsumer
     {
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode)]
         public delegate void EventRecordCallback(
@@ -860,132 +860,133 @@ namespace etwlib
         #endregion
 
         #region APIs
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhGetEventInformation(
-            [In] nint Event, // EVENT_RECORD*
-            [In] uint TdhContextCount,
-            [In] nint TdhContext,
-            [Out] nint Buffer, // TRACE_EVENT_INFO*
-            [In, Out] ref uint BufferSize
+        [LibraryImport("tdh.dll", SetLastError = true)]
+        internal static partial uint TdhGetEventInformation(
+            nint Event, // EVENT_RECORD*
+            uint TdhContextCount,
+            nint TdhContext,
+            nint Buffer, // TRACE_EVENT_INFO*
+            ref uint BufferSize
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhGetEventMapInformation(
-            [In] nint Event, // EVENT_RECORD*
-            [In] string MapName,
-            [Out] nint Buffer, // EVENT_MAP_INFO*
-            [In, Out] ref uint BufferSize
+        [LibraryImport("tdh.dll", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+        internal static partial uint TdhGetEventMapInformation(
+            nint Event, // EVENT_RECORD*
+            string MapName,
+            nint Buffer, // EVENT_MAP_INFO*
+            ref uint BufferSize
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhFormatProperty(
-            [In] nint TraceEventInfo, // TRACE_EVENT_INFO*
-            [In, Optional] nint MapInfo,  // EVENT_MAP_INFO*
-            [In] uint PointerSize,
-            [In] TdhInputType PropertyInType,
-            [In] TdhOutputType PropertyOutType,
-            [In] ushort PropertyLength,
-            [In] ushort UserDataLength,
-            [In] nint UserData,           // BYTE*
-            [In, Out] ref uint BufferSize,
-            [Out, Optional] nint Buffer,  // WCHAR*
-            [In, Out] ref ushort UserDataConsumed
+        [LibraryImport("tdh.dll", SetLastError = true)]
+        internal static partial uint TdhFormatProperty(
+            nint TraceEventInfo, // TRACE_EVENT_INFO*
+            nint MapInfo,  // EVENT_MAP_INFO*
+            uint PointerSize,
+            TdhInputType PropertyInType,
+            TdhOutputType PropertyOutType,
+            ushort PropertyLength,
+            ushort UserDataLength,
+            nint UserData,           // BYTE*
+            ref uint BufferSize,
+            nint Buffer,  // WCHAR*
+            ref ushort UserDataConsumed
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhEnumerateProviders(
-            [In] nint Buffer,
-            [In, Out] ref uint BufferSize
+        [LibraryImport("tdh.dll", SetLastError = true)]
+        internal static partial uint TdhEnumerateProviders(
+            nint Buffer,
+            ref uint BufferSize
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhEnumerateProvidersForDecodingSource(
-            [In] DecodingSource DecodingSource,
-            [In] nint Buffer,
-            [In] uint BufferSize,
-            [Out] out uint RequiredSize
+        [LibraryImport("tdh.dll", SetLastError = true)]
+        internal static partial uint TdhEnumerateProvidersForDecodingSource(
+            DecodingSource DecodingSource,
+            nint Buffer,
+            uint BufferSize,
+            out uint RequiredSize
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhEnumerateManifestProviderEvents(
-            [In] ref Guid ProviderGuid,
-            [Out] nint Buffer, // PROVIDER_EVENT_INFO*
-            [In, Out] ref uint BufferSize
+        [LibraryImport("tdh.dll", SetLastError = true)]
+        internal static partial uint TdhEnumerateManifestProviderEvents(
+            ref Guid ProviderGuid,
+            nint Buffer, // PROVIDER_EVENT_INFO*
+            ref uint BufferSize
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhGetManifestEventInformation(
-            [In] ref Guid ProviderGuid,
-            [In] nint EventDescriptor, // EVENT_DESCRIPTOR*
-            [Out] nint Buffer, // TRACE_EVENT_INFO*
-            [In, Out] ref uint BufferSize
+        [LibraryImport("tdh.dll", SetLastError = true)]
+        internal static partial uint TdhGetManifestEventInformation(
+            ref Guid ProviderGuid,
+            nint EventDescriptor, // EVENT_DESCRIPTOR*
+            nint Buffer, // TRACE_EVENT_INFO*
+            ref uint BufferSize
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhCreatePayloadFilter(
-            [In] ref Guid ProviderGuid,
-            [In] nint EventDescriptor, // EVENT_DESCRIPTOR*
-            [In] [MarshalAs(UnmanagedType.U1)] bool MatchAny,
-            [In] uint PayloadPredicateCount,
-            [In] nint PayloadPredicates, // PAYLOAD_FILTER_PREDICATE*
-            [In, Out] ref nint PayloadFilter    // PVOID*
+        [LibraryImport("tdh.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.U4)]
+        internal static partial uint TdhCreatePayloadFilter(
+            ref Guid ProviderGuid,
+            nint EventDescriptor, // EVENT_DESCRIPTOR*
+            [MarshalAs(UnmanagedType.U1)] bool MatchAny,
+            uint PayloadPredicateCount,
+            nint PayloadPredicates, // PAYLOAD_FILTER_PREDICATE*
+            ref nint PayloadFilter    // PVOID*
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhDeletePayloadFilter(
-            [In] ref nint PayloadFilter    // PVOID*
+        [LibraryImport("tdh.dll", SetLastError = true)]
+        internal static partial uint TdhDeletePayloadFilter(
+            ref nint PayloadFilter    // PVOID*
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhAggregatePayloadFilters(
-            [In] uint PayloadFilterCount,
+        [LibraryImport("tdh.dll", SetLastError = true)]
+        internal static partial uint TdhAggregatePayloadFilters(
+            uint PayloadFilterCount,
             [In] nint[] PayloadFilterPointers, // PVOID*
             [In] byte[] EventMatchAllFlags, // PBOOLEAN
-            [In, Out] nint EventFilterDescriptor // EVENT_FILTER_DESCRIPTOR*
+            nint EventFilterDescriptor // EVENT_FILTER_DESCRIPTOR*
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhCleanupPayloadEventFilterDescriptor(
-            [In] nint EventFilterDescriptor    // EVENT_FILTER_DESCRIPTOR*
+        [LibraryImport("tdh.dll", SetLastError = true)]
+        internal static partial uint TdhCleanupPayloadEventFilterDescriptor(
+            nint EventFilterDescriptor    // EVENT_FILTER_DESCRIPTOR*
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhLoadManifest(
-            [In] string Manifest
+        [LibraryImport("tdh.dll", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+        internal static partial uint TdhLoadManifest(
+            string Manifest
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhUnloadManifest(
-            [In] string Manifest
+        [LibraryImport("tdh.dll", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+        internal static partial uint TdhUnloadManifest(
+            string Manifest
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhGetAllEventsInformation(
-            [In] nint Event,    // PEVENT_RECORD
-            [In, Optional] nint WbemService,    // PVOID
-            [Out] out uint Index,
-            [Out] out uint Count,
-            [In, Out] ref nint Buffer,  // PTRACE_INFO*
-            [In, Out] ref uint BufferSize
+        [LibraryImport("tdh.dll", SetLastError = true)]
+        internal static partial uint TdhGetAllEventsInformation(
+            nint Event,    // PEVENT_RECORD
+            nint WbemService,    // PVOID
+            out uint Index,
+            out uint Count,
+            ref nint Buffer,  // PTRACE_INFO*
+            ref uint BufferSize
         );
 
-        [DllImport("tdh.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint TdhQueryProviderFieldInformation(
-            [In] ref Guid ProviderGuid,
-            [In] ulong EventFieldValue,
-            [In] EVENT_FIELD_TYPE EventFieldType,
-            [In, Out] nint Buffer, // PPROVIDER_FIELD_INFOARRAY
-            [In, Out] ref uint BufferSize
+        [LibraryImport("tdh.dll", SetLastError = true)]
+        internal static partial uint TdhQueryProviderFieldInformation(
+            ref Guid ProviderGuid,
+            ulong EventFieldValue,
+            EVENT_FIELD_TYPE EventFieldType,
+            nint Buffer, // PPROVIDER_FIELD_INFOARRAY
+            ref uint BufferSize
         );
 
-        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint EnumerateTraceGuidsEx(
-            [In] NativeTraceControl.TRACE_QUERY_INFO_CLASS InfoClass,
-            [In] nint InBuffer,
-            [In] uint InBufferSize,
-            [In, Out] nint OutBuffer,
-            [In] uint OutBufferSize,
-            [In, Out] ref uint ReturnLength
+        [LibraryImport("advapi32.dll", SetLastError = true)]
+        internal static partial uint EnumerateTraceGuidsEx(
+            NativeTraceControl.TRACE_QUERY_INFO_CLASS InfoClass,
+            nint InBuffer,
+            uint InBufferSize,
+            nint OutBuffer,
+            uint OutBufferSize,
+            ref uint ReturnLength
         );
         #endregion
 

--- a/PayloadFilter.cs
+++ b/PayloadFilter.cs
@@ -162,14 +162,14 @@ namespace etwlib
             try
             {
                 eventPointer = Marshal.AllocHGlobal(
-                    Marshal.SizeOf(typeof(EVENT_DESCRIPTOR)));
+                    Marshal.SizeOf<EVENT_DESCRIPTOR>());
                 if (eventPointer == nint.Zero)
                 {
                     throw new Exception("Out of memory");
                 }
                 Marshal.StructureToPtr(m_Event, eventPointer, false);
 
-                var predicateSize = Marshal.SizeOf(typeof(PAYLOAD_FILTER_PREDICATE));
+                var predicateSize = Marshal.SizeOf<PAYLOAD_FILTER_PREDICATE>();
                 predicatesPointer = Marshal.AllocHGlobal(
                     predicateSize * m_Predicates.Count);
                 if (predicatesPointer == nint.Zero)

--- a/ProviderParser.cs
+++ b/ProviderParser.cs
@@ -97,8 +97,7 @@ namespace etwlib
                     throw new Exception(error);
                 }
 
-                var providerInfoList = (PROVIDER_ENUMERATION_INFO)Marshal.PtrToStructure(
-                    buffer, typeof(PROVIDER_ENUMERATION_INFO))!;
+                var providerInfoList = Marshal.PtrToStructure<PROVIDER_ENUMERATION_INFO>(buffer);
                 if (providerInfoList.NumberOfProviders == 0)
                 {
                     throw new Exception("There are no ETW providers.");
@@ -110,8 +109,7 @@ namespace etwlib
 
                 for (int i = 0; i < providerInfoList.NumberOfProviders; i++)
                 {
-                    var providerInfo = (TRACE_PROVIDER_INFO)Marshal.PtrToStructure(
-                        pointer, typeof(TRACE_PROVIDER_INFO))!;
+                    var providerInfo = Marshal.PtrToStructure<TRACE_PROVIDER_INFO>(pointer);
                     var provider = new ParsedEtwProvider();
                     provider.Id = providerInfo.ProviderGuid;
                     //
@@ -139,7 +137,7 @@ namespace etwlib
                     }
 
                     results.Add(provider);
-                    pointer = nint.Add(pointer, Marshal.SizeOf(typeof(TRACE_PROVIDER_INFO)));
+                    pointer = nint.Add(pointer, Marshal.SizeOf<TRACE_PROVIDER_INFO>());
                 }
 
                 results.Sort();
@@ -697,10 +695,9 @@ namespace etwlib
         List<ParsedEtwEvent>
         ParseProviderEventArray(Guid ProviderGuid, nint EventArrayBuffer)
         {
-            var array = (PROVIDER_EVENT_INFO)Marshal.PtrToStructure(
-                EventArrayBuffer, typeof(PROVIDER_EVENT_INFO))!;
-            int offset = Marshal.OffsetOf(typeof(PROVIDER_EVENT_INFO),
-                    "EventDescriptorsArray").ToInt32();
+            var array = Marshal.PtrToStructure<PROVIDER_EVENT_INFO>(EventArrayBuffer);
+            int offset = (int)Marshal.OffsetOf<PROVIDER_EVENT_INFO>(
+                    "EventDescriptorsArray").ToInt64();
             nint arrayStart = nint.Add(EventArrayBuffer, offset);
             Debug.Assert(array.NumberOfEvents > 0);
             var events = MarshalHelper.MarshalArray<EVENT_DESCRIPTOR>(arrayStart,
@@ -712,7 +709,7 @@ namespace etwlib
             try
             {
                 eventDescriptorBuffer = Marshal.AllocHGlobal(
-                    Marshal.SizeOf(typeof(EVENT_DESCRIPTOR)));
+                    Marshal.SizeOf<EVENT_DESCRIPTOR>());
                 if (eventDescriptorBuffer == nint.Zero)
                 {
                     throw new Exception("Out of memory");
@@ -810,10 +807,9 @@ namespace etwlib
                 {
                     return results;
                 }
-                var array = (PROVIDER_FIELD_INFOARRAY)Marshal.PtrToStructure(
-                    buffer, typeof(PROVIDER_FIELD_INFOARRAY))!;
-                int offset = Marshal.OffsetOf(typeof(PROVIDER_FIELD_INFOARRAY),
-                        "FieldInfoArray").ToInt32();
+                var array = Marshal.PtrToStructure<PROVIDER_FIELD_INFOARRAY>(buffer);
+                int offset = (int)Marshal.OffsetOf<PROVIDER_FIELD_INFOARRAY>(
+                        "FieldInfoArray").ToInt64();
                 nint arrayStart = nint.Add(buffer, offset);
                 Debug.Assert(array.NumberOfElements > 0);
                 var fields = MarshalHelper.MarshalArray<PROVIDER_FIELD_INFO>(arrayStart,

--- a/RealTimeTrace.cs
+++ b/RealTimeTrace.cs
@@ -204,7 +204,7 @@ namespace etwlib
             Trace(TraceLoggerType.RealTimeTrace,
                   TraceEventType.Information,
                   $"Opening existing RealTimeTrace {Name}...");
-            var logFilePointer = Marshal.AllocHGlobal(Marshal.SizeOf(logfile));
+            var logFilePointer = Marshal.AllocHGlobal(Marshal.SizeOf<EVENT_TRACE_LOGFILE>());
             Marshal.StructureToPtr(logfile, logFilePointer, false);
             var handle = OpenTrace(logFilePointer);
             Marshal.FreeHGlobal(logFilePointer);
@@ -225,7 +225,7 @@ namespace etwlib
         GenerateTraceProperties()
         {
             var loggerName = Encoding.Unicode.GetBytes(m_SessionName + "\0");
-            var loggerNameLocation = Marshal.SizeOf(typeof(EVENT_TRACE_PROPERTIES));
+            var loggerNameLocation = Marshal.SizeOf<EVENT_TRACE_PROPERTIES>();
             int total = loggerNameLocation + loggerName.Length;
             var buffer = Marshal.AllocHGlobal(total);
             var properties = new EVENT_TRACE_PROPERTIES();

--- a/SessionParser.cs
+++ b/SessionParser.cs
@@ -83,19 +83,19 @@ namespace etwlib
                         " or empty buffer.");
                 }
 
-                int numProviders = (int)bufferSize / Marshal.SizeOf(typeof(Guid));
+                int numProviders = (int)bufferSize / Marshal.SizeOf<Guid>();
                 var pointer = buffer;
 
                 for (int i = 0; i < numProviders; i++)
                 {
-                    var guid = (Guid)Marshal.PtrToStructure(pointer, typeof(Guid))!;
+                    var guid = Marshal.PtrToStructure<Guid>(pointer);
                     var session = GetSessions(guid);
                     if (session == null)
                     {
                         continue;
                     }
                     results.AddRange(session);
-                    pointer = nint.Add(pointer, Marshal.SizeOf(typeof(Guid)));
+                    pointer = nint.Add(pointer, Marshal.SizeOf<Guid>());
                 }
 
                 results.Sort();
@@ -129,7 +129,7 @@ namespace etwlib
 
         public static List<ParsedEtwSession>? GetSessions(Guid ProviderId)
         {
-            var inBufferSize = (uint)Marshal.SizeOf(typeof(Guid));
+            var inBufferSize = (uint)Marshal.SizeOf<Guid>();
             if (Utilities.IsBufferSizeTooLarge(inBufferSize))
             {
                 throw new Exception($"Requested buffer size {inBufferSize} is too large for allocation.");
@@ -197,9 +197,8 @@ namespace etwlib
                 }
 
                 var pointer = outBuffer;
-                var info = (TRACE_GUID_INFO)Marshal.PtrToStructure(
-                    pointer, typeof(TRACE_GUID_INFO))!;
-                pointer = nint.Add(pointer, Marshal.SizeOf(typeof(TRACE_GUID_INFO)));
+                var info = Marshal.PtrToStructure<TRACE_GUID_INFO>(pointer);
+                pointer = nint.Add(pointer, Marshal.SizeOf<TRACE_GUID_INFO>());
 
                 //
                 // NB: there can be multiple instances of a provider with the same
@@ -207,16 +206,15 @@ namespace etwlib
                 //
                 for (int i = 0; i < info.InstanceCount; i++)
                 {
-                    var instance = (TRACE_PROVIDER_INSTANCE_INFO)Marshal.PtrToStructure(
-                        pointer, typeof(TRACE_PROVIDER_INSTANCE_INFO))!;
+                    var instance = Marshal.PtrToStructure<TRACE_PROVIDER_INSTANCE_INFO>(pointer);
                     if (instance.EnableCount > 0)
                     {
-                        var sessionPointer = nint.Add(pointer, Marshal.SizeOf(
-                            typeof(TRACE_PROVIDER_INSTANCE_INFO)));
+                        var sessionPointer = nint.Add(pointer,
+                            Marshal.SizeOf<TRACE_PROVIDER_INSTANCE_INFO>());
                         for (int j = 0; j < instance.EnableCount; j++)
                         {
-                            var sessionInfo = (TRACE_ENABLE_INFO)Marshal.PtrToStructure(
-                                sessionPointer, typeof(TRACE_ENABLE_INFO))!;
+                            var sessionInfo = Marshal.PtrToStructure<TRACE_ENABLE_INFO>(
+                                sessionPointer);
                             var enabledProvider = new SessionEnabledProvider(
                                 ProviderId,
                                 instance.Pid,
@@ -236,7 +234,7 @@ namespace etwlib
                             }
                             session!.EnabledProviders.Add(enabledProvider);
                             sessionPointer = nint.Add(sessionPointer,
-                                Marshal.SizeOf(typeof(TRACE_ENABLE_INFO)));
+                                Marshal.SizeOf<TRACE_ENABLE_INFO>());
                         }
                     }
                     if (instance.NextOffset == 0)

--- a/TraceSession.cs
+++ b/TraceSession.cs
@@ -87,14 +87,13 @@ namespace etwlib
         {
             m_LogFile.BufferCallback = BufferCallback;
             m_LogFile.EventCallback = EventCallback;
-            var logFilePointer = Marshal.AllocHGlobal(Marshal.SizeOf(m_LogFile));
+            var logFilePointer = Marshal.AllocHGlobal(Marshal.SizeOf<EVENT_TRACE_LOGFILE>());
             Marshal.StructureToPtr(m_LogFile, logFilePointer, false);
             var handle = OpenTrace(logFilePointer);
             //
             // Marshal the structure back so we can get the PerfFreq
             //
-            var logfile = (EVENT_TRACE_LOGFILE)Marshal.PtrToStructure(
-                logFilePointer, typeof(EVENT_TRACE_LOGFILE))!;
+            var logfile = Marshal.PtrToStructure<EVENT_TRACE_LOGFILE>(logFilePointer);
             Marshal.FreeHGlobal(logFilePointer);
             if (handle == -1 || handle == 0)
             {

--- a/TraceSession.cs
+++ b/TraceSession.cs
@@ -87,6 +87,19 @@ namespace etwlib
         {
             m_LogFile.BufferCallback = BufferCallback;
             m_LogFile.EventCallback = EventCallback;
+
+            //
+            // Pin both delegates for the duration of the native trace. Without
+            // this, the CLR is free to relocate or collect the thunk the kernel
+            // is holding a pointer to; when ETW fires an in-flight callback
+            // after ProcessTrace returns, the target may already be invalid
+            // and the runtime fires "Attempt to execute managed code after the
+            // .NET runtime thread state has been destroyed" during testhost
+            // shutdown or between tests.
+            //
+            var eventCallbackHandle = GCHandle.Alloc(EventCallback);
+            var bufferCallbackHandle = GCHandle.Alloc(BufferCallback);
+
             var logFilePointer = Marshal.AllocHGlobal(Marshal.SizeOf<EVENT_TRACE_LOGFILE>());
             Marshal.StructureToPtr(m_LogFile, logFilePointer, false);
             var handle = OpenTrace(logFilePointer);
@@ -97,6 +110,8 @@ namespace etwlib
             Marshal.FreeHGlobal(logFilePointer);
             if (handle == -1 || handle == 0)
             {
+                eventCallbackHandle.Free();
+                bufferCallbackHandle.Free();
                 var error = "OpenTrace() returned an invalid handle:  0x" +
                     Marshal.GetLastWin32Error().ToString("X");
                 Trace(TraceLoggerType.TraceSession,
@@ -141,6 +156,17 @@ namespace etwlib
             finally
             {
                 CloseTrace(handle);
+
+                //
+                // ETW can deliver one or more in-flight callbacks after
+                // ProcessTrace returns and even briefly after CloseTrace
+                // unwinds. Keep both delegate handles alive a little longer
+                // so any final callback hits a live target, then release.
+                //
+                GC.KeepAlive(EventCallback);
+                GC.KeepAlive(BufferCallback);
+                eventCallbackHandle.Free();
+                bufferCallbackHandle.Free();
             }
         }
 

--- a/UnitTests/FilterByExeNameTests.cs
+++ b/UnitTests/FilterByExeNameTests.cs
@@ -104,6 +104,14 @@ namespace UnitTests
                             }
                             Assert.Contains(Path.GetFileName(process.MainModule.FileName.ToLower()), ExeName);
                         }
+                        catch (ArgumentException)
+                        {
+                            // The process has already exited between the kernel
+                            // emitting the event and this callback running. On
+                            // busy CI agents short-lived svchost instances die
+                            // often enough that this path is expected.
+                            return;
+                        }
                         catch (InvalidOperationException)
                         {
                             return;

--- a/UnitTests/Shared.cs
+++ b/UnitTests/Shared.cs
@@ -23,6 +23,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 
+// Every test in this suite creates a real ETW session named
+// "Unit Test Real-Time Tracing". If two classes execute in parallel they
+// race on that name, causing sporadic ProcessTrace() failures (observed
+// 0x57 / 0x1069). Force serial execution for the whole assembly.
+[assembly: DoNotParallelize]
+
 namespace UnitTests
 {
     public static class Shared

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0-windows7.0</TargetFramework>
+		<TargetFramework>net10.0-windows7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<PublishSingleFile>true</PublishSingleFile>
 		<SelfContained>false</SelfContained>

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -22,29 +22,36 @@ using static etwlib.NativeTraceConsumer;
 
 namespace etwlib
 {
-    public static class MSStoreAppPackageHelper
+    public static partial class MSStoreAppPackageHelper
     {
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        static extern int GetPackageFullName(
-                [In] nint hProcess,
-                [In, Out] ref uint packageFullNameLength,
-                [Out] StringBuilder fullName);
+        [LibraryImport("kernel32.dll", EntryPoint = "GetPackageFullNameW", SetLastError = true)]
+        private static unsafe partial int GetPackageFullName(
+                nint hProcess,
+                ref uint packageFullNameLength,
+                char* fullName);
 
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        static extern int GetApplicationUserModelId(
-            [In] nint hProcess,
-            [In, Out] ref uint applicationUserModelIdLength,
-            [Out] StringBuilder applicationUserModelId);
+        [LibraryImport("kernel32.dll", EntryPoint = "GetApplicationUserModelIdW", SetLastError = true)]
+        private static unsafe partial int GetApplicationUserModelId(
+            nint hProcess,
+            ref uint applicationUserModelIdLength,
+            char* applicationUserModelId);
 
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        static extern int ParseApplicationUserModelId(
-            [In] string applicationUserModelId,
-            [In, Out] ref uint packageFamilyNameLength,
-            [In] StringBuilder packageFamilyName,
-            [In, Out] ref uint packageRelativeApplicationIdLength,
-            [Out] StringBuilder packageRelativeApplicationId);
+        [LibraryImport("kernel32.dll", EntryPoint = "ParseApplicationUserModelIdW", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+        private static unsafe partial int ParseApplicationUserModelId(
+            string applicationUserModelId,
+            ref uint packageFamilyNameLength,
+            char* packageFamilyName,
+            ref uint packageRelativeApplicationIdLength,
+            char* packageRelativeApplicationId);
 
-        public static Tuple<string, string>? GetPackage(nint ProcessHandle)
+        private static string BufferToString(char[] buffer, uint length)
+        {
+            // length includes the null terminator; trim it.
+            int actual = length > 0 ? (int)length - 1 : 0;
+            return new string(buffer, 0, Math.Min(actual, buffer.Length));
+        }
+
+        public static unsafe Tuple<string, string>? GetPackage(nint ProcessHandle)
         {
             uint bufferLength = 1024;
 
@@ -53,41 +60,56 @@ namespace etwlib
             // consists of identifying info like: name, publisher, architecture, etc.
             // This is what the ETW filter type EVENT_FILTER_TYPE_PACKAGE_ID  wants.
             //
-            var packageId = new StringBuilder((int)bufferLength);
-            var result = GetPackageFullName(ProcessHandle, ref bufferLength, packageId);
+            var packageIdBuffer = new char[bufferLength];
+            var packageIdLen = bufferLength;
+            int result;
+            fixed (char* pPackageId = packageIdBuffer)
+            {
+                result = GetPackageFullName(ProcessHandle, ref packageIdLen, pPackageId);
+            }
             if (result != ERROR_SUCCESS)
             {
                 return null;
             }
 
-            var userModelId = new StringBuilder((int)bufferLength);
-            result = GetApplicationUserModelId(ProcessHandle, ref bufferLength, userModelId);
+            var userModelIdBuffer = new char[bufferLength];
+            var userModelIdLen = bufferLength;
+            fixed (char* pUserModelId = userModelIdBuffer)
+            {
+                result = GetApplicationUserModelId(ProcessHandle, ref userModelIdLen, pUserModelId);
+            }
             if (result != ERROR_SUCCESS)
             {
                 return null;
             }
 
             //
-            // The ETW filter type EVENT_FILTER_TYPE_PACKAGE_APP_ID wants the 
+            // The ETW filter type EVENT_FILTER_TYPE_PACKAGE_APP_ID wants the
             // "package-relative APP ID (PRAID)" which must be parsed from
             // the "application user model ID".
             //
+            var packageFamilyBuffer = new char[bufferLength];
             var packageFamilyLength = bufferLength;
-            var packageFamily = new StringBuilder((int)packageFamilyLength);
+            var relativeAppIdBuffer = new char[bufferLength];
             var relativeAppIdLength = bufferLength;
-            var relativeAppId = new StringBuilder((int)relativeAppIdLength);
-            result = ParseApplicationUserModelId(userModelId.ToString(),
-                ref packageFamilyLength,
-                packageFamily,
-                ref relativeAppIdLength,
-                relativeAppId);
+            var userModelIdStr = BufferToString(userModelIdBuffer, userModelIdLen);
+            fixed (char* pFamily = packageFamilyBuffer)
+            fixed (char* pRelative = relativeAppIdBuffer)
+            {
+                result = ParseApplicationUserModelId(userModelIdStr,
+                    ref packageFamilyLength,
+                    pFamily,
+                    ref relativeAppIdLength,
+                    pRelative);
+            }
             if (result != ERROR_SUCCESS)
             {
                 return null;
             }
 
             return new Tuple<string, string>(
-                packageId.ToString(), relativeAppId.ToString());
+                BufferToString(packageIdBuffer, packageIdLen),
+                BufferToString(relativeAppIdBuffer, relativeAppIdLength));
         }
     }
 

--- a/etwlib.csproj
+++ b/etwlib.csproj
@@ -1,23 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <IsAotCompatible>true</IsAotCompatible>
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <Title>etwlib</Title>
     <Authors>Aaron LeMasters</Authors>
     <Description>etwlib is a .NET library that provides raw access to Microsoft Windows Event Tracing (ETW) infrastructure including providers, manifests, and event data. etwlib is meant to be the foundation for larger projects that leverage its capabilities and is distributed as a Nuget package.</Description>
     <PackageProjectUrl>https://github.com/lilhoser/etwlib</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/lilhoser/etwlib</RepositoryUrl>
-    <PackageTags>microsoft;windows;etw;tracing;debugging</PackageTags>
+    <PackageTags>microsoft;windows;etw;tracing;debugging;aot</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <AssemblyVersion>1.12.0</AssemblyVersion>
-    <FileVersion>1.12.0</FileVersion>
-    <Version>1.12.0</Version>
+    <AssemblyVersion>2.0.0</AssemblyVersion>
+    <FileVersion>2.0.0</FileVersion>
+    <Version>2.0.0</Version>
+    <PackageReleaseNotes>v2.0.0: Retarget to net10.0-windows7.0. Migrate all P/Invoke from [DllImport] to [LibraryImport] source-generated marshalling for AOT compatibility. Marked IsAotCompatible + IsTrimmable. Public-API preserved — existing [UnmanagedFunctionPointer] delegate callbacks still work; callers should provide static callbacks for full AOT compatibility.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Modernize etwlib to be shippable inside Native-AOT or heavily trimmed consumers. Retarget to net10.0-windows7.0 and migrate the entire P/Invoke surface to source-generated `[LibraryImport]` marshalling.

Public-API preserved — no signature or member changes. Existing consumers that pass static (non-closure) callbacks will be AOT-safe without any source changes.

## Changes

### Library retarget
- `net9.0-windows7.0` → `net10.0-windows7.0`
- `IsAotCompatible=true`, `IsTrimmable=true`, `EnableTrimAnalyzer=true`

### P/Invoke source-gen migration
- 22 `[DllImport]` declarations → `[LibraryImport]` across advapi32 (StartTrace, ControlTrace, OpenTrace, CloseTrace, ProcessTrace, EnableTraceEx2, EnumerateTraceGuidsEx) and tdh (TdhGetEventInformation, TdhFormatProperty, TdhEnumerateProviders, TdhCreatePayloadFilter, etc.).
- Explicit `EntryPoint = "...W"` on the string-taking advapi32 APIs — LibraryImport does **not** auto-append the `W` suffix the way DllImport did under `CharSet.Unicode`.
- `NativeTraceControl` and `NativeTraceConsumer` marked `partial`.
- 3 kernel32 `[DllImport]`s in `MSStoreAppPackageHelper` migrated. `StringBuilder` is not supported by LibraryImport; replaced with `char*` + pinned `char[]` buffers inside `fixed` blocks.

### Marshal.SizeOf / PtrToStructure cleanup
- 72 `IL3050` warnings cleared: swapped `Marshal.SizeOf(typeof(X))` → `Marshal.SizeOf<X>()` and `(X)Marshal.PtrToStructure(ptr, typeof(X))` → `Marshal.PtrToStructure<X>(ptr)` throughout EnabledProvider, EventParser, EventParserBuffers, PayloadFilter, ProviderParser, RealTimeTrace, SessionParser, TraceSession.
- Added `[DynamicallyAccessedMembers]` on `MarshalHelper`'s generic `T` to satisfy IL2091.

### Version bump
- AssemblyVersion / FileVersion / Version: `1.12.0` → `2.0.0`. The framework bump (net9 → net10) is a hard break for any consumer still on net9.

## Verification

| | |
|---|---|
| `dotnet build -p:EnableTrimAnalyzer=true -p:IsAotCompatible=true` | 0 errors, 0 IL warnings (38 pre-existing CS8600/CS8618 nullability warnings unchanged) |
| UnitTests retargeted to net10 | builds clean |
| Full test run vs `main` baseline | same pass/fail shape — flaky `ProcessTrace` failures reproduce identically on `main` without any of this PR's changes |

## Why public-API preserved instead of function-pointer callbacks

The plan originally called for changing `TraceSession.Consume` to take `delegate*<nint, void>` function pointers. In practice the existing `[UnmanagedFunctionPointer]` delegate types already marshal correctly under AOT **as long as** callers provide static (non-closure) delegates — the analyzer no longer flags them. Keeping the delegate signature avoids a gratuitous break for any downstream consumer and defers the `[UnmanagedCallersOnly]` refactor to the call sites, where closures actually matter.

## Consumers

Only known consumer today is [`endpoint`](https://github.com/ahumai/endpoint) (via NuGet). Its EtwCollector.cs update will land as a separate PR (PR-11 in the EG-420 stack) that bumps etwlib to 2.0.0 and converts its instance-lambda callbacks to static `[UnmanagedCallersOnly]` methods + GCHandle state lookup.

## Release notes / NuGet
Package `etwlib.2.0.0.nupkg` is produced by `GeneratePackageOnBuild=true` but **not yet published** — waiting for review of this PR.