### PR TITLE
Branch-protection hardening: OIDC publish, SHA-pinned actions, AOT smoke test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,10 @@ jobs:
       - name: checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Publish AOT smoke test
-        # Promote AOT/trim warnings to errors so a regression in etwlib's
-        # AOT posture (new [DllImport], non-blittable struct, reflection
-        # serialization, etc.) fails this job.
-        run: >
-          dotnet publish AotSmokeTest/AotSmokeTest.csproj
-          -c Release
-          -r win-x64
-          /p:TreatWarningsAsErrors=true
-          /p:WarningsAsErrors="IL2026;IL2055;IL2057;IL2058;IL2059;IL2060;IL2061;IL2062;IL2063;IL2064;IL2065;IL2066;IL2067;IL2068;IL2069;IL2070;IL2071;IL2072;IL2073;IL2074;IL2075;IL2076;IL2077;IL2078;IL2079;IL2080;IL2081;IL2082;IL2083;IL2084;IL2085;IL2086;IL2087;IL2088;IL2089;IL2090;IL2091;IL2092;IL2093;IL2094;IL2095;IL2096;IL2097;IL2098;IL2099;IL2100;IL2101;IL2102;IL2103;IL2104;IL2105;IL2106;IL2107;IL2108;IL2109;IL2110;IL2111;IL2112;IL2113;IL2114;IL2115;IL2116;IL3000;IL3001;IL3002;IL3050;IL3051;IL3052;IL3053;IL3054;IL3055;IL3056'
+        # Warning-as-error policy lives in AotSmokeTest.csproj
+        # (TreatWarningsAsErrors=true, TrimmerSingleWarn=false) so a
+        # regression in etwlib's AOT posture surfaces here as an error.
+        run: dotnet publish AotSmokeTest/AotSmokeTest.csproj -c Release -r win-x64
       - name: Run AOT smoke test
         # Exercises the LibraryImport surface and the EventRecordCallback /
         # BufferCallback delegate-marshalling path under AOT (the path that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,23 @@
 name: CI
+
 on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
 jobs:
   etwlib_Unit_Tests:
     runs-on: windows-latest
     steps:
-      # setup .NET using setup-dotnet action
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce  # v2.0.0
       - name: Setup NuGet
-        uses: nuget/setup-nuget@v2
-      - uses: actions/cache@v4
+        uses: nuget/setup-nuget@d105a947828025cd7a980103c35ba2bfae586d0f  # v2.0.2
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
@@ -26,3 +30,38 @@ jobs:
           msbuild.exe etwlib.sln /nologo /nr:false /p:platform="Any CPU" /p:configuration="Release"
       - name: Test
         run: dotnet test --no-restore --verbosity normal
+
+  etwlib_AotSmokeTest:
+    runs-on: windows-latest
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
+      - name: checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - name: Publish AOT smoke test
+        # Promote AOT/trim warnings to errors so a regression in etwlib's
+        # AOT posture (new [DllImport], non-blittable struct, reflection
+        # serialization, etc.) fails this job.
+        run: >
+          dotnet publish AotSmokeTest/AotSmokeTest.csproj
+          -c Release
+          -r win-x64
+          /p:TreatWarningsAsErrors=true
+          /p:WarningsAsErrors="IL2026;IL2055;IL2057;IL2058;IL2059;IL2060;IL2061;IL2062;IL2063;IL2064;IL2065;IL2066;IL2067;IL2068;IL2069;IL2070;IL2071;IL2072;IL2073;IL2074;IL2075;IL2076;IL2077;IL2078;IL2079;IL2080;IL2081;IL2082;IL2083;IL2084;IL2085;IL2086;IL2087;IL2088;IL2089;IL2090;IL2091;IL2092;IL2093;IL2094;IL2095;IL2096;IL2097;IL2098;IL2099;IL2100;IL2101;IL2102;IL2103;IL2104;IL2105;IL2106;IL2107;IL2108;IL2109;IL2110;IL2111;IL2112;IL2113;IL2114;IL2115;IL2116;IL3000;IL3001;IL3002;IL3050;IL3051;IL3052;IL3053;IL3054;IL3055;IL3056'
+      - name: Run AOT smoke test
+        # Exercises the LibraryImport surface and the EventRecordCallback /
+        # BufferCallback delegate-marshalling path under AOT (the path that
+        # broke pre-fix in 8a2fe371 — pinning regression on this code path
+        # would surface here as a crash rather than a build error).
+        shell: pwsh
+        run: |
+          $exe = "AotSmokeTest/bin/Release/net10.0-windows7.0/win-x64/publish/AotSmokeTest.exe"
+          if (-not (Test-Path $exe)) {
+            Write-Error "AOT-published binary not found at $exe"
+            exit 1
+          }
+          & $exe
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "AOT smoke test exited with code $LASTEXITCODE"
+            exit $LASTEXITCODE
+          }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,27 +11,30 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write       # gh release create writes the Release object
+  id-token: write       # mint OIDC token for nuget.org trusted publishing
+  attestations: write   # publish SLSA build provenance
+
 jobs:
   publish:
     name: Pack & push to nuget.org
     runs-on: windows-latest
     timeout-minutes: 30
-
-    permissions:
-      contents: read
+    environment: production
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce  # v2.0.0
 
       - name: Setup NuGet
-        uses: nuget/setup-nuget@v2
+        uses: nuget/setup-nuget@d105a947828025cd7a980103c35ba2bfae586d0f  # v2.0.2
 
       - name: Resolve version
         id: version
@@ -59,9 +62,6 @@ jobs:
         run: msbuild.exe etwlib.sln /nologo /nr:false /p:platform="Any CPU" /p:configuration="Release"
 
       - name: Test (library tests must pass before we ship)
-        # --no-build so we don't redundantly rebuild what msbuild already produced.
-        # Target UnitTests.csproj explicitly instead of the solution to match the
-        # fast path the CI workflow uses.
         run: dotnet test UnitTests/UnitTests.csproj --no-build --no-restore --verbosity normal --configuration Release
 
       - name: Locate package
@@ -77,23 +77,88 @@ jobs:
           "path=$($pkg.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Upload package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: etwlib-${{ steps.version.outputs.version }}
           path: ${{ steps.package.outputs.path }}
           if-no-files-found: error
 
-      - name: Push to nuget.org
+      - name: Attest build provenance
+        # Signs the .nupkg via Sigstore (keyless, uses the OIDC token).
+        # Publishes an attestation to GitHub's transparency log that
+        # consumers can verify with: gh attestation verify <nupkg> --repo lilhoser/etwlib
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
+        with:
+          subject-path: ${{ steps.package.outputs.path }}
+
+      - name: Acquire nuget.org access token via OIDC trusted publishing
+        # This step exchanges the GitHub Actions OIDC token for a short-lived
+        # nuget.org API key. Replaces the long-lived NUGET_API_KEY secret.
+        #
+        # Prerequisite: register this workflow as a trusted publisher for the
+        # 'etwlib' package on nuget.org (Manage Package -> Trusted Publishers):
+        #   - Repository:  lilhoser/etwlib
+        #   - Workflow:    .github/workflows/publish.yml
+        #   - Environment: production
+        #
+        # The endpoint URL and audience below match nuget.org's documented
+        # OIDC trusted-publishing protocol; verify against the current docs at
+        # https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing
+        # if this step fails with 401/404 — protocol details may have evolved.
         if: ${{ inputs.dry_run != true }}
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        id: nuget_token
         shell: pwsh
+        env:
+          NUGET_OIDC_AUDIENCE: 'nuget'
+          NUGET_OIDC_ENDPOINT: 'https://www.nuget.org/api/v2/oidc/access_token'
         run: |
-          if (-not $env:NUGET_API_KEY) {
-            Write-Error "NUGET_API_KEY secret is not configured in this repo. Add it under Settings → Secrets and variables → Actions."
+          # 1. Mint a GitHub Actions OIDC token bound to nuget.org as audience
+          $idTokenUrl = "$($env:ACTIONS_ID_TOKEN_REQUEST_URL)&audience=$($env:NUGET_OIDC_AUDIENCE)"
+          $idTokenResp = Invoke-RestMethod -Uri $idTokenUrl `
+            -Headers @{ Authorization = "Bearer $($env:ACTIONS_ID_TOKEN_REQUEST_TOKEN)" }
+          $idToken = $idTokenResp.value
+          if (-not $idToken) {
+            Write-Error "Failed to obtain GitHub Actions OIDC token"
             exit 1
           }
+
+          # 2. Exchange the OIDC token for a nuget.org access token
+          $body = @{ token = $idToken } | ConvertTo-Json
+          try {
+            $resp = Invoke-RestMethod -Method POST -Uri $env:NUGET_OIDC_ENDPOINT `
+              -Body $body -ContentType 'application/json'
+          } catch {
+            Write-Error "nuget.org OIDC exchange failed: $($_.Exception.Message)"
+            Write-Error "Verify the trusted publisher is registered for package 'etwlib' on nuget.org"
+            Write-Error "and that the workflow path / environment match the registration."
+            exit 1
+          }
+
+          if (-not $resp.access_token) {
+            Write-Error "nuget.org returned no access_token in response"
+            exit 1
+          }
+
+          # Mask the token in logs and pass it to subsequent steps
+          Write-Host "::add-mask::$($resp.access_token)"
+          "access_token=$($resp.access_token)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Push to nuget.org
+        if: ${{ inputs.dry_run != true }}
+        shell: pwsh
+        run: |
           dotnet nuget push "${{ steps.package.outputs.path }}" `
             --source https://api.nuget.org/v3/index.json `
-            --api-key $env:NUGET_API_KEY `
+            --api-key "${{ steps.nuget_token.outputs.access_token }}" `
             --skip-duplicate
+
+      - name: Create GitHub Release
+        if: ${{ inputs.dry_run != true }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: pwsh
+        run: |
+          gh release create $env:GITHUB_REF_NAME `
+            --title $env:GITHUB_REF_NAME `
+            --generate-notes `
+            "${{ steps.package.outputs.path }}"

--- a/AotSmokeTest/AotSmokeTest.csproj
+++ b/AotSmokeTest/AotSmokeTest.csproj
@@ -12,6 +12,11 @@
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <IsPackable>false</IsPackable>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <!-- Surface every trim warning individually rather than a single per-assembly summary. -->
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <!-- Promote any warning in this project to an error so AOT regressions in the
+         smoke test surface area (callback marshalling, native interop) fail the build. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AotSmokeTest/AotSmokeTest.csproj
+++ b/AotSmokeTest/AotSmokeTest.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsPackable>false</IsPackable>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\etwlib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AotSmokeTest/Program.cs
+++ b/AotSmokeTest/Program.cs
@@ -1,0 +1,75 @@
+// AOT smoke test for etwlib.
+//
+// Runs as a published Native AOT executable in CI. Exercises the surface area
+// most sensitive to AOT regressions:
+//   - LibraryImport-based P/Invoke (the v2.0.0 modernization)
+//   - EventRecordCallback / BufferCallback delegate marshalling (the path
+//     fixed in 8a2fe371 — pinning of managed delegates passed to native code)
+//
+// Mirrors the realtime-trace pattern from UnitTests/RealTimeTraceTests.cs so
+// privilege requirements are identical (user-mode RPC provider, satisfied by
+// the windows-latest runner's Administrators-group membership).
+//
+// Exits 0 on success; non-zero on any failure path. No assertions framework —
+// kept dependency-free so the AOT publish closure stays minimal.
+
+using System.Runtime.InteropServices;
+using etwlib;
+using static etwlib.NativeTraceConsumer;
+using static etwlib.NativeTraceControl;
+
+const int TargetEventCount = 10;
+var rpcProviderGuid = new Guid("6ad52b32-d609-4be9-ae07-ce8dae937e39");
+
+TraceLogger.Initialize();
+TraceLogger.SetLevel(System.Diagnostics.SourceLevels.Error);
+
+int eventsConsumed = 0;
+int parseFailures = 0;
+
+using (var trace = new RealTimeTrace("etwlib AOT Smoke Test"))
+using (var parserBuffers = new EventParserBuffers())
+{
+    trace.AddProvider(rpcProviderGuid, "RPC", EventTraceLevel.Information, 0xFFFFFFFFFFFFFFFF, 0);
+    trace.Start();
+
+    trace.Consume(
+        new EventRecordCallback(eventPtr =>
+        {
+            // Use the generic Marshal.PtrToStructure<T> overload — the legacy
+            // (IntPtr, Type) overload triggers IL3050 (RequiresDynamicCode)
+            // and breaks under AOT. This is the pattern consumers must use.
+            var evt = Marshal.PtrToStructure<EVENT_RECORD>(eventPtr);
+            try
+            {
+                var parser = new EventParser(evt, parserBuffers, trace.GetPerfFreq());
+                _ = parser.Parse();
+            }
+            catch
+            {
+                parseFailures++;
+            }
+            eventsConsumed++;
+        }),
+        new BufferCallback(_ =>
+        {
+            return eventsConsumed >= TargetEventCount ? 0u : 1u;
+        }));
+}
+
+Console.WriteLine($"events consumed: {eventsConsumed}, parse failures: {parseFailures}");
+
+if (eventsConsumed < TargetEventCount)
+{
+    Console.Error.WriteLine($"FAIL: only {eventsConsumed} events consumed (target {TargetEventCount})");
+    return 1;
+}
+
+if (parseFailures > 0)
+{
+    Console.Error.WriteLine($"FAIL: {parseFailures} parse failures");
+    return 2;
+}
+
+Console.WriteLine("AOT smoke test passed");
+return 0;

--- a/etwlib.csproj
+++ b/etwlib.csproj
@@ -28,10 +28,13 @@ v2.0.0: Retarget to net10.0-windows7.0. Migrate all P/Invoke from [DllImport] to
   <ItemGroup>
     <Compile Remove="TestResults\**" />
     <Compile Remove="UnitTests\**" />
+    <Compile Remove="AotSmokeTest\**" />
     <EmbeddedResource Remove="TestResults\**" />
     <EmbeddedResource Remove="UnitTests\**" />
+    <EmbeddedResource Remove="AotSmokeTest\**" />
     <None Remove="TestResults\**" />
     <None Remove="UnitTests\**" />
+    <None Remove="AotSmokeTest\**" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Bundles six related repo-hardening changes from the audit interview. Pairs with the repo-settings changes already applied directly via `gh api` (see ROLLBACK in `C:\Users\lilho\etwlib-rollback\ROLLBACK.md`):

- ✅ Free public-repo security features enabled (Dependabot security updates, vulnerability alerts, secret scanning + push protection)
- ✅ `production` environment created with required reviewer + `refs/tags/v*.*.*` deployment branch policy
- ✅ Tag ruleset on `v*.*.*` blocking force-update, deletion, and unauthorized creation
- ⏳ `main` branch ruleset — applied **after this PR merges**, requiring `etwlib_Unit_Tests` and `etwlib_AotSmokeTest` to pass

## What's in this PR

### `publish.yml` rewrite
- **OIDC trusted publishing** replaces the long-lived `NUGET_API_KEY` secret. Token-exchange step mints a short-lived nuget.org access token from the GitHub Actions OIDC token. **You must register this workflow as a trusted publisher on nuget.org before the next release.**
- `actions/attest-build-provenance` signs the .nupkg via Sigstore (keyless). Consumers verify with `gh attestation verify <nupkg> --repo lilhoser/etwlib`.
- `gh release create` publishes a GitHub Release with auto-generated notes and the .nupkg attached after a successful push.
- Job references `environment: production` — every release now waits for an "Approve deployment" click.

### `ci.yml` changes
- New `etwlib_AotSmokeTest` job: publishes `AotSmokeTest/` with `PublishAot=true` and runs it against the RPC realtime ETW provider. Catches AOT regressions in the LibraryImport surface (build time) and the callback-marshalling code path (runtime — the path fixed in 8a2fe371).
- Explicit workflow-level `permissions: contents: read`.

### Both workflows
- All third-party actions pinned to 40-char SHAs with `# v4.x.x` comments. Defends against tag-pointer attacks (cf. tj-actions/changed-files, March 2025).

### New files
- `.github/dependabot.yml` — weekly updates for `github-actions` and `nuget` ecosystems. Keeps SHA pins fresh.
- `AotSmokeTest/AotSmokeTest.csproj` — `PublishAot=true`, `EnableTrimAnalyzer=true`, references `etwlib.csproj`.
- `AotSmokeTest/Program.cs` — replicates `RealTimeTraceTests.Basic`'s pattern under AOT. Uses `Marshal.PtrToStructure<T>` (AOT-safe generic overload) instead of `(IntPtr, Type)` (IL3050).

### `etwlib.csproj`
- Adds `AotSmokeTest/**` to `Compile`/`EmbeddedResource`/`None` removal globs so the smoke test doesn't bleed into etwlib's own assembly.

## Reviewer prerequisites

**Before merging:** confirm trusted publisher is registered on nuget.org for the `etwlib` package:
- Repository: `lilhoser/etwlib`
- Workflow: `.github/workflows/publish.yml`
- Environment: `production`

If the OIDC endpoint URL or audience differ from what the trusted-publishing protocol expects, the next release will fail — the static `NUGET_API_KEY` is left in place as a fallback you can revert to.

## Test plan

- [ ] CI green: `etwlib_Unit_Tests` and `etwlib_AotSmokeTest` both pass on this PR
- [ ] Dependabot has scanned the repo and not flagged anything in this PR
- [ ] Verify `production` environment shows the deployment branch policy `v*.*.*` (tag) under Settings → Environments
- [ ] Verify tag ruleset is active under Settings → Rules → Rulesets
- [ ] Verify security features show enabled under Settings → Code security