### PR TITLE
ci(publish): let OIDC token-exchange run in dry_run mode

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,10 @@ jobs:
         # OIDC trusted-publishing protocol; verify against the current docs at
         # https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing
         # if this step fails with 401/404 — protocol details may have evolved.
-        if: ${{ inputs.dry_run != true }}
+        #
+        # NOTE: this step runs in dry_run mode too — that's the only way to
+        # verify the trusted-publisher registration without committing to a
+        # real release. Only the actual nuget push below is dry_run-gated.
         id: nuget_token
         shell: pwsh
         env:


### PR DESCRIPTION
Tiny follow-up to PR #12.

The dry_run input previously skipped both the OIDC handshake and the nuget push, so there was no way to validate the trusted-publisher registration without cutting a real release. Move the dry_run gate so only the actual nuget push is skipped — the OIDC step always runs.

After merge: `gh workflow run publish.yml --repo lilhoser/etwlib -f dry_run=true` will exercise the full OIDC handshake against nuget.org and fail loudly if the registration is wrong, without uploading anything.