### PR TITLE
ci(publish): use official NuGet/login action for OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,59 +92,28 @@ jobs:
           subject-path: ${{ steps.package.outputs.path }}
 
       - name: Acquire nuget.org access token via OIDC trusted publishing
-        # This step exchanges the GitHub Actions OIDC token for a short-lived
-        # nuget.org API key. Replaces the long-lived NUGET_API_KEY secret.
+        # The official NuGet/login action handles the OIDC handshake — fetches
+        # the GitHub Actions OIDC token with the right audience, exchanges it
+        # against nuget.org's token endpoint, and exposes a short-lived API
+        # key (1-hour TTL) via outputs.NUGET_API_KEY.
         #
         # Prerequisite: register this workflow as a trusted publisher for the
-        # 'etwlib' package on nuget.org (Manage Package -> Trusted Publishers):
-        #   - Repository:  lilhoser/etwlib
-        #   - Workflow:    .github/workflows/publish.yml
-        #   - Environment: production
-        #
-        # The endpoint URL and audience below match nuget.org's documented
-        # OIDC trusted-publishing protocol; verify against the current docs at
-        # https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing
-        # if this step fails with 401/404 — protocol details may have evolved.
+        # 'etwlib' package on nuget.org (Username menu -> Trusted Publishing):
+        #   - Repository owner: lilhoser
+        #   - Repository:       etwlib
+        #   - Workflow file:    publish.yml      (filename only — no path)
+        #   - Environment:      production       (optional, recommended)
         #
         # NOTE: this step runs in dry_run mode too — that's the only way to
         # verify the trusted-publisher registration without committing to a
-        # real release. Only the actual nuget push below is dry_run-gated.
-        id: nuget_token
-        shell: pwsh
-        env:
-          NUGET_OIDC_AUDIENCE: 'nuget'
-          NUGET_OIDC_ENDPOINT: 'https://www.nuget.org/api/v2/oidc/access_token'
-        run: |
-          # 1. Mint a GitHub Actions OIDC token bound to nuget.org as audience
-          $idTokenUrl = "$($env:ACTIONS_ID_TOKEN_REQUEST_URL)&audience=$($env:NUGET_OIDC_AUDIENCE)"
-          $idTokenResp = Invoke-RestMethod -Uri $idTokenUrl `
-            -Headers @{ Authorization = "Bearer $($env:ACTIONS_ID_TOKEN_REQUEST_TOKEN)" }
-          $idToken = $idTokenResp.value
-          if (-not $idToken) {
-            Write-Error "Failed to obtain GitHub Actions OIDC token"
-            exit 1
-          }
-
-          # 2. Exchange the OIDC token for a nuget.org access token
-          $body = @{ token = $idToken } | ConvertTo-Json
-          try {
-            $resp = Invoke-RestMethod -Method POST -Uri $env:NUGET_OIDC_ENDPOINT `
-              -Body $body -ContentType 'application/json'
-          } catch {
-            Write-Error "nuget.org OIDC exchange failed: $($_.Exception.Message)"
-            Write-Error "Verify the trusted publisher is registered for package 'etwlib' on nuget.org"
-            Write-Error "and that the workflow path / environment match the registration."
-            exit 1
-          }
-
-          if (-not $resp.access_token) {
-            Write-Error "nuget.org returned no access_token in response"
-            exit 1
-          }
-
-          # Mask the token in logs and pass it to subsequent steps
-          Write-Host "::add-mask::$($resp.access_token)"
-          "access_token=$($resp.access_token)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        # real release. Only the nuget push below is dry_run-gated.
+        id: nuget_login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841  # v1.2.0
+        with:
+          # nuget.org profile name of the package owner (NOT email).
+          # Hardcoded since etwlib's owner is publicly listed on nuget.org;
+          # move to ${{ secrets.NUGET_USER }} if ownership changes.
+          user: lilhoser
 
       - name: Push to nuget.org
         if: ${{ inputs.dry_run != true }}
@@ -152,7 +121,7 @@ jobs:
         run: |
           dotnet nuget push "${{ steps.package.outputs.path }}" `
             --source https://api.nuget.org/v3/index.json `
-            --api-key "${{ steps.nuget_token.outputs.access_token }}" `
+            --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" `
             --skip-duplicate
 
       - name: Create GitHub Release


### PR DESCRIPTION
Fixes the 404 from the previous attempt. The hand-rolled token-exchange step guessed at `https://www.nuget.org/api/v2/oidc/access_token` based on incomplete public docs — that URL doesn't exist.

The official `NuGet/login@v1` action (Microsoft-maintained, [docs](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)) handles the full OIDC handshake correctly: requests the GitHub Actions OIDC token with the right audience, hits the actual nuget.org token endpoint, and exposes a 1-hour API key via `outputs.NUGET_API_KEY`.

Pinned to SHA `8d196754...` (v1.2.0). User identity hardcoded as `lilhoser` per the public package listing — easy to flip to a secret later.

After merge, we re-test via the same dry_run path: `gh workflow run publish.yml --ref main -f dry_run=true`.